### PR TITLE
Fix: BranchAndroid.GetInstance

### DIFF
--- a/Branch-Xamarin-SDK.Droid/BranchAndroid.cs
+++ b/Branch-Xamarin-SDK.Droid/BranchAndroid.cs
@@ -42,7 +42,7 @@ namespace BranchXamarinSDK
 			}
 		}
 
-		public static BranchAndroid getInstance() {
+		public static BranchAndroid GetInstance() {
 			return (BranchAndroid)branch;
 		}
 


### PR DESCRIPTION
The docs [here](https://github.com/BranchMetrics/Xamarin-Deferred-Deep-Linking-SDK#android-with-forms) and [here](https://github.com/BranchMetrics/Xamarin-Deferred-Deep-Linking-SDK#android-without-forms) were saying to call this method:

    BranchAndroid.GetInstance().SetNewUrl(intent.Data);

Unfortunately, the correct method seemed to incorrectly be spelled `BranchAndroid.getInstance` (lowercase 'g'). When calling `BranchAndroid.GetInstance` it would actually call [`Branch.GetInstance`](https://github.com/BranchMetrics/Xamarin-Deferred-Deep-Linking-SDK/blob/73f05790b01e7780df5f28eb44ff40ee21b1dd87/Branch-Xamarin-SDK/Branch.cs#L134), which returned a parent `Branch` instance, which doesn't have a `SetNewUrl` method that accepts an `Android.Net.Uri`.

By fixing this typo, it will call the `GetInstance` method directly on `BranchAndroid` and get back an Android-specific type instance with the correct [`SetNewUrl` method](https://github.com/BranchMetrics/Xamarin-Deferred-Deep-Linking-SDK/blob/73f05790b01e7780df5f28eb44ff40ee21b1dd87/Branch-Xamarin-SDK.Droid/BranchAndroid.cs#L39)

## Workaround Until Fixed

Before this fix is released, you could work around this by casting the result back to `BranchAndroid` before calling the correct method.

    // Ensure we get the updated link identifier when the app is opened from the
    // background with a new link.
    protected override void OnNewIntent(Intent intent) {
        ((BranchAndroid)BranchAndroid.GetInstance()).SetNewUrl(intent.Data);
    }